### PR TITLE
Fix typos on code for slide 67.

### DIFF
--- a/code_for_each_slide.txt
+++ b/code_for_each_slide.txt
@@ -307,11 +307,12 @@ REST_FRAMEWORK = {
     'rest_framework.renderers.BrowsableAPIRenderer',
     'rest_framework_xml.renderers.XMLRenderer',
   ),
-  ‘DEFAULT_PARSER_CLASSES’: (
-    ‘rest_framework.parsers.JSONParser’,
-    ‘rest_framework.parsers.FormParser’,
-    ‘rest_framework.parsers.MultiPartParser’,
-    ‘rest_framework_xml.parsers.XMLRenderer’, 
+  'DEFAULT_PARSER_CLASSES': (
+    'rest_framework.parsers.JSONParser',
+    'rest_framework.parsers.FormParser',
+    'rest_framework.parsers.MultiPartParser',
+    'rest_framework_xml.parsers.XMLParser', 
+  ),
 }
 
 *********************


### PR DESCRIPTION
Here's a fix for a few of the typos on the code_for_each_slide.txt file that came up in the tutorial today.
